### PR TITLE
feat: update docker image for thullyodev/myapp-fastapi:v5

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: fastapi-app
-        image: thullyodev/myapp-fastapi:v4
+        image: thullyodev/myapp-fastapi:v5
         ports:
         - containerPort: 5000
 


### PR DESCRIPTION
This PR update the kubernetes manifests for use the new image created: `thullyodev/myapp-fastapi:v5`